### PR TITLE
Ag: Artificial root nodes are now generic in their base syntax type, i.e. Root<T>

### DIFF
--- a/src/Aardvark.Base.FSharp/Ag.fs
+++ b/src/Aardvark.Base.FSharp/Ag.fs
@@ -57,9 +57,10 @@ module Ag =
 
 
     
+    type Root<'a>(child : obj) =
+        member x.Child = child
 
-
-    type Root = { Child : obj }
+    let rootType = typeof<Root<_>>.GetGenericTypeDefinition()
 
     //since some use-cases may need to deferr attribute-evaluation we provide a
     //mechanism to capture the state needed therefore. this is realized by simply
@@ -136,7 +137,7 @@ module Ag =
 
     //given a scope we can search for inherited attributes by navigating to parent scopes 
     //when needed.
-    let rec private tryGetInhAttributeScopeInternal (cacheScopes : List<Scope>) (scope : Scope) (name : string) : Option<obj> =
+    let rec private tryGetInhAttributeScopeInternal (node : obj) (cacheScopes : List<Scope>) (scope : Scope) (name : string) : Option<obj> =
         if logging then Log.start "tryGetInhAttributeScopeInternal %s on scope: %A " name scope.Path
         match scope.TryFindCacheValue name with
             //if the current scope contains a cache-value for <name> we may simply return it
@@ -170,16 +171,21 @@ module Ag =
                                     //the tree. (auto-inherit)
                                     | _ -> cacheScopes.Add(scope)
                                            if logging then Log.line "autoinh."
-                                           let r = tryGetInhAttributeScopeInternal cacheScopes parent name
+                                           let r = tryGetInhAttributeScopeInternal parent.source cacheScopes parent name
                                            if logging then Log.stop ()
                                            r
 
                         //otherwise the attribute could not be found
                         | _ -> 
-                            match tryFindSemanticFunction(typeof<Root>, name) with
-                                | Some(f) -> 
+                            // find root semantic function by querying Root<S>, where S :> sourceType.
+                            let sourceType = node.GetType()
+                            match tryFindRootSemantics(rootType,sourceType, name) with
+                                | Some(f,baseInterface) -> 
                                     if logging then Log.line "invoking sem: %A" f
-                                    f.Fun({ Child = scope.source }) |> ignore
+                                    // TODO: further optimize this
+                                    let rootInstanceType = rootType.MakeGenericType([|baseInterface|])
+                                    let root = System.Activator.CreateInstance(rootInstanceType, [| scope.source |])
+                                    f.Fun(root) |> ignore
                                     match getValueStore scope.source name with
                                         | Some v -> clearValueStore()
                                                     if logging then Log.stop "no cache, searched attrib, found inh sem, adding to scope cache"
@@ -189,10 +195,10 @@ module Ag =
                                     if logging then Log.stop "sem fun not found. adding none."
                                     scope.AddCache name None
 
-    let inline private tryGetInhAttributeScope (scope : Scope) (name : string) : Option<obj> =
+    let inline private tryGetInhAttributeScope (node : obj) (scope : Scope) (name : string) : Option<obj> =
         if logging then Log.start "tryGetInhAttributeScope %s on scope: %A " name scope.Path
         let l = List<Scope>()
-        let r = tryGetInhAttributeScopeInternal l scope name
+        let r = tryGetInhAttributeScopeInternal node l scope name
         l |> Seq.iter (fun si -> si.AddCache name r |> ignore)
         if logging then if r.IsNone then Log.stop " --> result: none" else Log.stop " --> result: some"
         r 
@@ -225,16 +231,16 @@ module Ag =
 
     //when not given a scope we need to use the currentScope
     //these functions are called by the ?-operator
-    let inline private tryGetInhAttribute (o : obj) (name : string) =
-        match o with
-            | :? Scope as scope -> tryGetInhAttributeScope scope name
+    let private tryGetInhAttribute (node : obj) (name : string) =
+        match node with
+            | :? Scope as scope -> tryGetInhAttributeScope node scope name
             | _ -> 
-                let s = rootScope.Value.GetChildScope(o)
+                let s = rootScope.Value.GetChildScope node
                 match s.cache.TryGetValue name with
                     | (true, v) -> v
                     | _ ->
                         match currentScope.Value.parent with
-                            | Some parent -> tryGetInhAttributeScope (parent.GetChildScope o) name
+                            | Some parent -> tryGetInhAttributeScope node (parent.GetChildScope node) name
                             | None -> None
 
     let private tryGetSynAttribute (o : obj) (name : string) =
@@ -322,6 +328,6 @@ module Ag =
             member x.TryGetAttributeValue(name : string) : Error<'a> =
                 match tryGetSynAttributeScope x name with
                     | Some v -> Success (v |> unbox<'a>)
-                    | None -> match tryGetInhAttributeScope x name with
+                    | None -> match tryGetInhAttributeScope null x name with
                                 | Some v -> Success (v |> unbox<'a>)
                                 | None -> Error "not found"

--- a/src/Aardvark.Base.FSharp/Ag.fs
+++ b/src/Aardvark.Base.FSharp/Ag.fs
@@ -180,12 +180,11 @@ module Ag =
                             // find root semantic function by querying Root<S>, where S :> sourceType.
                             let sourceType = node.GetType()
                             match tryFindRootSemantics(rootType,sourceType, name) with
-                                | Some(f,baseInterface) -> 
+                                | Some(f,rootCreator) -> 
                                     if logging then Log.line "invoking sem: %A" f
                                     // TODO: further optimize this
-                                    let rootInstanceType = rootType.MakeGenericType([|baseInterface|])
-                                    let root = System.Activator.CreateInstance(rootInstanceType, [| scope.source |])
-                                    f.Fun(root) |> ignore
+                                    let rootInstance = rootCreator.Invoke scope.source 
+                                    f.Fun(rootInstance) |> ignore
                                     match getValueStore scope.source name with
                                         | Some v -> clearValueStore()
                                                     if logging then Log.stop "no cache, searched attrib, found inh sem, adding to scope cache"

--- a/src/Aardvark.Base.FSharp/AgHelpers.fs
+++ b/src/Aardvark.Base.FSharp/AgHelpers.fs
@@ -140,6 +140,7 @@ module AgHelpers =
                    v
 
     let private sfCache = Dictionary<Type, Dictionary<string, Option<SemanticFunction>>>()
+    let private rootSfCache = Dictionary<Type * string, Option<SemanticFunction*Type>>()
 
     let private addSemanticFunction (nodeType : Type, name : string) (sf : Option<SemanticFunction>) =
         lock sfCache (fun () ->
@@ -188,6 +189,37 @@ module AgHelpers =
                                            else
                                                 reg <| Some(SemanticFunction(getSemanticObject(mi.DeclaringType), mi.DeclaringType, mi :?> MethodInfo))
                         | _ -> reg None
+
+    // finds the semantic function s for Root<S when S :> callerType) and returns s,S where S is
+    // the interface of the syntactic family.
+    // Note that, due to OOPness the lookup might be expensive if a type implements many interfaces
+    // which are required for querying a syntax base type.
+    // This is not too bad, since there should not be to many of them. Additionally the result is 
+    // cached and occurs only when querying the root inh semantics the first time.
+    let internal tryFindRootSemantics(genericRoot : Type, callerType : Type, name : string) : Option<SemanticFunction * Type> =
+        let key = callerType,name
+        lock rootSfCache (fun () ->
+            match rootSfCache.TryGetValue key with
+             | (true,v) -> v
+             | _ ->
+                // get all Root<S> candidates
+                let interfaces = callerType.GetInterfaces() 
+                let instantiatedRoots = 
+                    [ for i in interfaces do
+                        let concreteRoot = genericRoot.MakeGenericType([|i|])      
+                        yield concreteRoot,i    
+                    ]
+                // use tryFindSemanticFunction to select the proper concrete Root<concreteType :> S> method.
+                // also return the chosen S in order to create root objects afterwards
+                let possibleSemanticFunctions = instantiatedRoots |> List.map (fun (concrete,interfaceType) -> tryFindSemanticFunction(concrete,name), interfaceType)
+                let s = 
+                    match possibleSemanticFunctions with
+                        | [Some (singleSem),baseInterfaceType] -> Some (singleSem, baseInterfaceType)
+                        | [single] -> failwith "ambigous root semantics for type %s of semantic: %s" callerType.FullName name
+                        | _ -> None
+                rootSfCache.[key] <- s
+                s
+        )
 
 
     let internal register (t : System.Type) = 

--- a/src/Tests/Aardvark.Base.FSharp.Tests/Aardvark.Base.FSharp.Tests.fsproj
+++ b/src/Tests/Aardvark.Base.FSharp.Tests/Aardvark.Base.FSharp.Tests.fsproj
@@ -60,6 +60,7 @@
   -->
   <ItemGroup>
     <Compile Include="TimeTests.fs" />
+    <Compile Include="PureAgTests.fs" />
     <Content Include="app.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Tests/Aardvark.Base.FSharp.Tests/PureAgTests.fs
+++ b/src/Tests/Aardvark.Base.FSharp.Tests/PureAgTests.fs
@@ -1,0 +1,55 @@
+﻿namespace Aardvark.Base.FSharp.Tests
+#nowarn "44"
+
+open System
+open Aardvark.Base
+open FsUnit
+open NUnit.Framework
+open Aardvark.Base.Ag
+open Aardvark.Base.AgHelpers
+
+module ``Ag Tests`` =
+
+    type F = interface end
+    type FA() =
+        interface F
+
+    type G = interface end
+    type GA() =
+        interface G
+
+    [<Semantic>]
+    type FSem() =
+        member x.SimpleInh(r : Root<F>) = r.Child?SimpleInh <- 1
+        member x.SimpleSyn(a : FA) : int = a?SimpleInh
+        member x.Syn(f : FA) : int = f?Inh
+        member x.Inh(r : Root<F>) = r.Child?Inh <- 1
+
+    [<Semantic>]
+    type GSem() =
+        member x.Syn(f : GA) : int  = f?Inh
+        member x.Inh(r : Root<G>) = r.Child?Inh <- 0
+
+    [<Test>]
+    let ``[Ag] simple semantic root test``() =
+        Aardvark.Init()
+
+        let f = FA()
+
+        let resultF = f?SimpleSyn()
+
+        resultF |> should equal 1
+
+    [<Test>]
+    let ``[Ag] simple multiple syntactic families``() =
+        Aardvark.Init()
+
+        let f = FA()
+        let g = GA()
+
+        let resultF = f?Syn()
+        let resultG = g?Syn()
+
+        resultF |> should equal 1
+        resultG |> should equal 0
+

--- a/src/Tests/Aardvark.Base.Incremental.Tests/AgTests.fs
+++ b/src/Tests/Aardvark.Base.Incremental.Tests/AgTests.fs
@@ -13,8 +13,10 @@ open FsUnit
 
 module AgTests =
     
+    type ITreeNode = interface end
     type TreeNode(name : string) =
         let mutable children = List.empty<TreeNode>
+        interface ITreeNode
         member x.Children 
             with get() = children
             and set value =
@@ -71,13 +73,13 @@ module AgTests =
                 ()
             temp
 
-        member x.ConcatName(r : Root) =
+        member x.ConcatName(r : Root<ITreeNode>) =
             x.AllChildren?ConcatName <- "0"
 
         member x.ConcatName(node : TreeNode) : unit =
             x.AllChildren?ConcatName <- node?ConcatName + "|" + node.Name
 
-        member x.SynName(r : Root) : string =
+        member x.SynName(r : Root<ITreeNode>) : string =
             "0"
 
         member x.SynName(n : SynTreeNode) : string =


### PR DESCRIPTION
This pull requests provides generic root nodes. With this, you can use different unrelated root semantic functions for each syntactic family.
Example:

```
    [<Semantic>]
    type FSem() =
        member x.Syn(f : FA) : int = f?Inh
        member x.Inh(r : Root<F>) = r.Child?Inh <- 1

    [<Semantic>]
    type GSem() =
        member x.Syn(f : GA) : int  = f?Inh
        member x.Inh(r : Root<G>) = r.Child?Inh <- 0
```

For queries on G, G root method of GSem is used, respectively for F.